### PR TITLE
Change the damage of traps that shoot projectiles

### DIFF
--- a/Common/GlobalProjectiles/VanillaTrapsDamage.cs
+++ b/Common/GlobalProjectiles/VanillaTrapsDamage.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace TerrariaCells.Common.GlobalProjectiles
+{
+    public class VanillaTrapsDamage : GlobalProjectile
+    {
+        public override void OnSpawn(Projectile projectile, IEntitySource source)
+        {
+            int[] trapProjectiles = {
+                ProjectileID.SpearTrap, ProjectileID.Boulder, ProjectileID.MiniBoulder,
+                ProjectileID.PoisonDart, ProjectileID.PoisonDartTrap, ProjectileID.GeyserTrap,
+                ProjectileID.SpikyBallTrap, ProjectileID.FlamesTrap, ProjectileID.FlamethrowerTrap
+            };
+
+            if (trapProjectiles.Contains(projectile.type))
+            {
+                projectile.damage = 25;
+            }
+        }
+    }
+}

--- a/Common/GlobalTiles/VanillaSpikesDamage.cs
+++ b/Common/GlobalTiles/VanillaSpikesDamage.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace TerrariaCells.Common.GlobalTiles
+{
+    public class VanillaSpikesDamage : GlobalTile
+    {
+    }
+}


### PR DESCRIPTION
Change the damage of traps that shoot projectiles to 50 in Classic Mode.

The traps include: Dart Trap, Super Dart Trap, Boulder, Flame Trap, Spiky Ball Trap, Spear Trap, Geyser
