### PR TITLE
Add system to remove vanilla behaviours for specified buffs and accessories

### DIFF
--- a/Common/GlobalItems/AccessoryEffects.cs
+++ b/Common/GlobalItems/AccessoryEffects.cs
@@ -134,6 +134,9 @@ namespace TerrariaCells.Common.GlobalItems
 					//I know suggestion is 25%, I'm going 33% because you're sacrificing SO MUCH for this boost to mana cost of all things
 					player.manaCost -= 0.33f;
 					break;
+				case ItemID.MagicCuffs:
+					modPlayer.magicCuffs = true;
+					break;
 				default:
 					orig.Invoke(player, item, hideVisual);
 					break;

--- a/Common/ModPlayers/AccessoryPlayer.cs
+++ b/Common/ModPlayers/AccessoryPlayer.cs
@@ -30,18 +30,31 @@ namespace TerrariaCells.Common.ModPlayers
 		public bool chlorophyteCoating; //Bullets and arrows become chlorophyte
 		public bool stalkerQuiver; //Summons a spectral arrow to hit targets hit by your arrows (deals 50% original damage)
 		private int stalkerQuiverTimer;
+		public bool magicCuffs; // restore 100 mana when taking damage
 
 		public override void Load()
 		{
-			IL_Player.OnHurt_Part2 += IL_Player_OnHurt_Part2;
+			//IL_Player.OnHurt_Part2 += IL_Player_OnHurt_Part2;
 			//IL_Player.ApplyEquipFunctional += IL_Player_ApplyEquipFunctional;
 		}
 		public override void Unload()
 		{
-			IL_Player.OnHurt_Part2 -= IL_Player_OnHurt_Part2;
+			//IL_Player.OnHurt_Part2 -= IL_Player_OnHurt_Part2;
 			//IL_Player.ApplyEquipFunctional -= IL_Player_ApplyEquipFunctional;
 		}
-		private void IL_Player_OnHurt_Part2(ILContext context)
+
+        public override void OnHurt(Player.HurtInfo info) {
+			if (this.magicCuffs) {
+				Player.statMana += 100;
+				if (Player.statMana > Player.statManaMax2) {
+					Player.statMana = Player.statManaMax2;				
+				}
+				Player.ManaEffect(100);
+			}
+        }
+
+		//[Unused]
+        private void IL_Player_OnHurt_Part2(ILContext context)
 		{
 			log4net.ILog GetInstanceLogger() => ModContent.GetInstance<TerrariaCells>().Logger;
 			try

--- a/Common/Systems/VanillaClearingSystem.cs
+++ b/Common/Systems/VanillaClearingSystem.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+
+namespace TerrariaCells.Common.Systems {
+    public class VanillaClearingSystem : ModSystem {
+        static readonly HashSet<int> BuffsToClear = [
+        ];
+        static readonly HashSet<int> AccessoriesToClear = [
+            ItemID.CelestialMagnet,
+            ItemID.NaturesGift,
+            ItemID.ArcaneFlower,
+            ItemID.ManaRegenerationBand,
+            ItemID.MagicCuffs,
+            ItemID.StalkersQuiver,
+            ItemID.AmmoBox,
+            ItemID.ChlorophyteDye,
+            ItemID.BallOfFuseWire,
+            ItemID.SniperScope,
+            ItemID.ReconScope,
+            ItemID.BerserkerGlove,
+            ItemID.SharkToothNecklace,
+            ItemID.Nazar,
+            ItemID.FeralClaws,
+            ItemID.ThePlan,
+            ItemID.ObsidianShield,
+            ItemID.FrozenTurtleShell,
+            ItemID.BandofRegeneration,
+            ItemID.FastClock,
+            ItemID.CelestialStone,
+        ];
+        public override void Load() {
+            On_NPC.UpdateNPC_BuffSetFlags += this.ClearBuffs;
+            On_Player.GrantArmorBenefits += this.ClearAccessories;
+        }
+
+        private void ClearAccessories(On_Player.orig_GrantArmorBenefits orig, Player self, Item armorPiece) {
+            if (!AccessoriesToClear.Contains(armorPiece.type)) {
+                orig(self, armorPiece);
+            }
+        }
+
+        private void ClearBuffs(On_NPC.orig_UpdateNPC_BuffSetFlags orig, NPC self, bool lowerBuffTime) {
+            for (int i = 0; i < NPC.maxBuffs; i++) {
+                if (BuffsToClear.Contains(self.buffType[i])) {
+                    // negative buffs are ignored by the original method
+                    self.buffType[i] = -self.buffType[i];
+                    if (lowerBuffTime) {
+                        // this would get skipped inside the method otherwise
+                        self.buffTime[i]--;
+                    }
+                }
+            }
+            orig(self, lowerBuffTime);
+            // restore the original buffs after we've run orig
+            for (int i = 0; i < NPC.maxBuffs; i++) {
+                if (BuffsToClear.Contains(-self.buffType[i])) {
+                    self.buffType[i] = -self.buffType[i];
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Nobody told me what buffs needed clearing so that's an empty list for now

I confirmed in-game that replaced accessories still work with their modded behaviour