### PR TITLE
Use color rarities to indicate item category

### DIFF
--- a/Common/GlobalItems/TierSystemGlobalItem.cs
+++ b/Common/GlobalItems/TierSystemGlobalItem.cs
@@ -31,8 +31,11 @@ namespace TerrariaCells.Common.GlobalItems
 
         public override void SetDefaults(Item item)
         {
-            item.rare = itemLevel;
-            Math.Clamp(item.rare, 0, 10);
+            // Lawro:
+            // Comment this because my task needs weapons to have Red rarity
+
+            //item.rare = itemLevel;
+            //Math.Clamp(item.rare, 0, 10);
         }
 
         public void AddLevels(Item item, int level)

--- a/Common/GlobalItems/VanillaReworksGlobalItem.cs
+++ b/Common/GlobalItems/VanillaReworksGlobalItem.cs
@@ -232,7 +232,7 @@ namespace TerrariaCells.Common.GlobalItems
                         item.rare = ItemRarityID.Green;
                         break;
                     case TerraCellsItemCategory.Potion:
-                        item.rare = ItemRarityID.Orange; // Amber-like
+                        item.rare = ItemRarityID.Quest; // Amber-like
                         break;
                     case TerraCellsItemCategory.Storage:
                         switch (InventoryManager.GetStorageItemSubcategorization(item.netID))
@@ -245,6 +245,9 @@ namespace TerrariaCells.Common.GlobalItems
                                 break;
                             case StorageItemSubcategorization.Coin:
                                 item.rare = ItemRarityID.White;
+                                break;
+                            default:
+                                item.rare = ItemRarityID.LightPurple;
                                 break;
                                 //default:
                                 //    item.rare = ItemRarityID.LightRed; // Large gems or other Storage items


### PR DESCRIPTION
Using custom rarities:
Weapons (Red)
Skills (Green)
Armor (Blue)
Healing potions (Amber)
Accessories (Yellow)
Large gems (Light Purple)