### PR TITLE
Adjust enemy stats

### DIFF
--- a/Common/GlobalNPCs/CombatNPC.cs
+++ b/Common/GlobalNPCs/CombatNPC.cs
@@ -166,6 +166,24 @@ namespace TerrariaCells.Common.GlobalNPCs
                     break;
                 #endregion
 
+                //Level 5
+                #region Caverns
+                case NPCID.GraniteFlyer: //Granite Elemental
+                    npc.lifeMax = 200;
+                    npc.damage = 80;
+                    break;
+                case NPCID.Skeleton:
+                    npc.lifeMax = 300;
+                    npc.damage = 60;
+                    break;
+                case NPCID.Tim:
+                    npc.lifeMax = 250;
+                    npc.damage = 60;
+                    break;
+                case NPCID.RockGolem:
+                    break;
+                #endregion
+
                 //Do early return if you don't want enemy to have 0 defence
                 //No point repeating the same line a bajillion times :)
                 default:

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Terraria;
+using Terraria.ID;
 using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 
@@ -13,8 +14,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 	{
 		public override bool AppliesToNPC(int npcType)
 		{
-			return npcType.Equals(Terraria.ID.NPCID.GoblinSorcerer);
-		}
+			//return npcType.Equals(Terraria.ID.NPCID.GoblinSorcerer);
+
+			return npcType == NPCID.GoblinSorcerer || npcType == NPCID.Tim;
+        }
 
 		const int Idle = 0;
 		const int Casting = 1;

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
@@ -76,7 +76,12 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 			{
 				NPC ball = NPC.NewNPCDirect(npc.GetSource_FromAI(), npc.Center, Terraria.ID.NPCID.ChaosBall, ai0: 1);
                 ball.target = npc.target;
-                ball.velocity = npc.DirectionTo(Main.player[npc.target].Center) * 3.6f;
+                //ball.velocity = npc.DirectionTo(Main.player[npc.target].Center) * 3.6f;
+                //ball.velocity = npc.DirectionTo(Main.player[npc.target].Center) * 5.0f;
+
+                float speed = npc.type == NPCID.Tim ? 7.2f : 3.6f;
+                ball.velocity = npc.DirectionTo(Main.player[npc.target].Center) * speed;
+
                 ball.damage = npc.damage;
 				ball.netUpdate = true;
 			}


### PR DESCRIPTION
Adjust enemy stats:
Granite Elemental to 200 HP, 80 damage
Skeleton to 300 HP, 60 damage
Tim to 250 HP, 60 damage. Give goblin sorcerer AI with faster chaos balls
set rock golem defense to zero (and the other enemies above) 
