### PR TITLE
Adjust Dungeon enemies stats

### DIFF
--- a/Common/GlobalNPCs/CombatNPC.cs
+++ b/Common/GlobalNPCs/CombatNPC.cs
@@ -159,9 +159,23 @@ namespace TerrariaCells.Common.GlobalNPCs
                 #endregion
 
                 //Level 4
-                #region Hive
-                case NPCID.Hornet:
-                    npc.lifeMax = 175;
+                //Hive?
+                #region Dungeon
+                case NPCID.DiabolistRed:
+                case NPCID.DiabolistWhite:
+                    npc.lifeMax = 125;
+                    npc.damage = 75;
+                    break;
+                case NPCID.RaggedCaster:
+                case NPCID.RaggedCasterOpenCoat:
+                    npc.lifeMax = 125;
+                    npc.damage = 60;
+                    break;
+                case NPCID.RustyArmoredBonesAxe:
+                case NPCID.RustyArmoredBonesFlail:
+                case NPCID.RustyArmoredBonesSword:
+                case NPCID.RustyArmoredBonesSwordNoArmor:
+                    npc.lifeMax = 400;
                     npc.damage = 60;
                     break;
                 #endregion


### PR DESCRIPTION
Diabolist - 125 HP. 75 damage. 0 defense.
Ragged caster - 125 HP. 60 damage. 0 defence.
Rusty armored bones - 400 HP. 60 damage. 0 defense.

Unfortunately can't complete the aggro adjustment at the moment, will do that ASAP.