### PR TITLE
More Enemy AI

### DIFF
--- a/Common/GlobalNPCs/BuffNPC.cs
+++ b/Common/GlobalNPCs/BuffNPC.cs
@@ -395,6 +395,9 @@ namespace TerrariaCells.Common.GlobalNPCs
 		//Handles debuff icons for enemies
 		public override void PostDraw(NPC npc, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
 		{
+            //Hide buffs when NPC can't display them (as with colour tinting)
+            if (!npc.canDisplayBuffs)
+                return;
 			//Don't do this draw step if you have debuff icons disabled
 			Configs.TerrariaCellsConfig.DebuffIndicators indicator = Configs.TerrariaCellsConfig.Instance.IndicatorType;
 			if ((indicator & Configs.TerrariaCellsConfig.DebuffIndicators.Icon) == Configs.TerrariaCellsConfig.DebuffIndicators.None)

--- a/Common/GlobalNPCs/CombatNPC.cs
+++ b/Common/GlobalNPCs/CombatNPC.cs
@@ -8,6 +8,8 @@ using TerrariaCells.Common.Utilities;
 
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using System.Linq;
+using Terraria.ModLoader.IO;
+using System.IO;
 
 namespace TerrariaCells.Common.GlobalNPCs
 {
@@ -58,6 +60,20 @@ namespace TerrariaCells.Common.GlobalNPCs
                 }
             }
         }
+
+        //As an aside, I hate that this is called "send extra AI" when it should just have been netsend like literally every other hook of its nature
+        //I'm not sending AI here, as it turns out. ]:/
+        public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)
+        {
+            bitWriter.WriteBit(npc.GetGlobalNPC<CombatNPC>().allowContactDamage);
+
+            bitWriter.Flush(binaryWriter);
+        }
+        public override void ReceiveExtraAI(NPC npc, BitReader bitReader, BinaryReader binaryReader)
+        {
+            npc.GetGlobalNPC<CombatNPC>().allowContactDamage = bitReader.ReadBit();
+        }
+
 
         public override void SetStaticDefaults()
 		{

--- a/Common/GlobalNPCs/CombatNPC.cs
+++ b/Common/GlobalNPCs/CombatNPC.cs
@@ -12,7 +12,39 @@ namespace TerrariaCells.Common.GlobalNPCs
 {
 	public class CombatNPC : GlobalNPC
 	{
-		public override bool InstancePerEntity => true;
+        public override void DrawEffects(NPC npc, ref Color drawColor)
+        {
+            if(allowContactDamage && npc.lifeMax > 1)
+            {
+                byte b;
+                byte b2;
+                byte b3;
+                if (!(npc.friendly || npc.catchItem > 0 || (npc.damage == 0 && npc.lifeMax == 5)))
+                {
+                    b = byte.MaxValue;
+                    b2 = 50;
+                    b3 = 50;
+                }
+                else
+                {
+                    return;
+                }
+                if (drawColor.R < b)
+                {
+                    drawColor.R = b;
+                }
+                if (drawColor.G < b2)
+                {
+                    drawColor.G = b2;
+                }
+                if (drawColor.B < b3)
+                {
+                    drawColor.B = b3;
+                }
+            }
+        }
+
+        public override bool InstancePerEntity => true;
 		public bool allowContactDamage = true;
 
 		public override bool CanHitPlayer(NPC npc, Player target, ref int cooldownSlot)
@@ -21,13 +53,13 @@ namespace TerrariaCells.Common.GlobalNPCs
 			return base.CanHitPlayer(npc, target, ref cooldownSlot);
 		}
 
-		public override Color? GetAlpha(NPC npc, Color drawColor)
-		{
-			Color? returnVal = base.GetAlpha(npc, drawColor);
-			if (npc.dontTakeDamage) returnVal = Color.Lerp(drawColor, Color.DarkSlateGray * 0.67f, 0.5f);
-			if (npc.GetGlobalNPC<CombatNPC>().allowContactDamage) returnVal = Color.Lerp(drawColor, Color.IndianRed * (drawColor.A / 255f), 0.3f);
-			return returnVal;
-		}
+		//public override Color? GetAlpha(NPC npc, Color drawColor)
+		//{
+		//	Color? returnVal = base.GetAlpha(npc, drawColor);
+		//	if (npc.dontTakeDamage) returnVal = Color.Lerp(drawColor, Color.DarkSlateGray * 0.67f, 0.5f);
+		//	if (npc.GetGlobalNPC<CombatNPC>().allowContactDamage) returnVal = Color.Lerp(drawColor, Color.IndianRed * (drawColor.A / 255f), 0.3f);
+		//	return returnVal;
+		//}
 
 		public static void ToggleContactDamage(NPC npc, bool value) => npc.GetGlobalNPC<CombatNPC>().allowContactDamage = value;
 

--- a/Common/GlobalNPCs/NPCHooks.cs
+++ b/Common/GlobalNPCs/NPCHooks.cs
@@ -13,7 +13,7 @@ using Terraria.ModLoader;
 using Terraria.ModLoader.Core;
 using static System.Net.Mime.MediaTypeNames;
 
-namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
+namespace TerrariaCells.Common.GlobalNPCs
 {
     //Took a little bit to wrap my head around how adding custom hooks works
     //Basically, if you want an NPC to have 'PreFindFrame,' have the respective class inherit 'PreFindFrame.INPC' or 'PreFindFrame.IGlobal'
@@ -35,9 +35,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
         internal static bool Invoke(NPC npc, int frameHeight)
         {
             if (npc.ModNPC is INPC n)
-            {
                 if(!n.PreFindFrame(frameHeight)) return false;
-            }
 
             foreach (GlobalNPC g in _hook.Enumerate(npc))
             {
@@ -139,7 +137,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                     log.Error($"Couldn't match IL Patch: {context.Method.Name} @ {cursor.Index}");
                     return;
                 }
-                ILLabel? IL_0161 = cursor.MarkLabel(); //IL Instruction 0161 (by ilSpy)
+                ILLabel IL_0161 = cursor.MarkLabel(); //IL Instruction 0161 (by ilSpy)
 
                 if (!cursor.TryGotoNext(MoveType.Before,
                         i => i.MatchLdarg0(), //NPC self
@@ -150,12 +148,12 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                     log.Error($"Couldn't match IL Patch: {context.Method.Name} @ {cursor.Index}");
                     return;
                 }
-                ILLabel? IL_04A1 = cursor.MarkLabel(); //IL Instruction 04A1 (by ilSpy)
+                ILLabel IL_04A1 = cursor.MarkLabel(); //IL Instruction 04A1 (by ilSpy)
 
                 cursor.GotoLabel(IL_0161, MoveType.Before);
                 cursor.Emit(OpCodes.Br, IL_04A1);
 
-                ILLabel? exitCritKbBonus = default;
+                ILLabel exitCritKbBonus = default;
                 if (!cursor.TryGotoNext(
                     MoveType.Before,
                     i => i.Match(OpCodes.Ldloc_2),
@@ -209,7 +207,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
         {
             bool isLikeTownNPC = npc.isLikeATownNPC;
             int? num = npc.ModNPC?.AnimationType;
-            int animationType = (num.HasValue && num.GetValueOrDefault() > 0) ? num.Value : npc.type;
+            int animationType = num.HasValue && num.GetValueOrDefault() > 0 ? num.Value : npc.type;
             bool shouldRunVanillAFrame = PreFindFrame.Invoke(npc, frameHeight);
             if (shouldRunVanillAFrame)
             {

--- a/Common/GlobalNPCs/NPCTypes/Caverns/RockGolem.cs
+++ b/Common/GlobalNPCs/NPCTypes/Caverns/RockGolem.cs
@@ -7,10 +7,11 @@ using Microsoft.Xna.Framework;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.GameContent;
+using Terraria.ModLoader;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Caverns
 {
-	public class RockGolem : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
+	public class RockGolem : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.RockGolem;
         //public override bool AppliesToNPC(int npcType)
@@ -208,7 +209,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Caverns
 				npc.velocity = vel1;
             }
 
-			if (npc.ai[0] > 60)
+			if (npc.ai[0] > 45)
 			{
 				npc.ai[1] = ThrowHands;
 				npc.ai[0] = 0;
@@ -441,5 +442,21 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Caverns
 		}
 
         public override bool? CanFallThroughPlatforms(NPC npc) => false;
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case ThrowHands:
+                        npc.ai[0] = 0;
+                        npc.ai[1] = Delay;
+                        npc.ai[2] = 0;
+                        npc.ai[3] = 0;
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Caverns/RockGolem.cs
+++ b/Common/GlobalNPCs/NPCTypes/Caverns/RockGolem.cs
@@ -7,11 +7,10 @@ using Microsoft.Xna.Framework;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.GameContent;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Caverns
 {
-	public class RockGolem : Terraria.ModLoader.GlobalNPC, Shared.PreFindFrame.IGlobal
+	public class RockGolem : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.RockGolem;
         //public override bool AppliesToNPC(int npcType)
@@ -76,7 +75,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Caverns
 				return;
 			}
 
-			if (!npc.dontTakeDamage)
+            CombatNPC.ToggleContactDamage(npc, false);
+
+            if (!npc.dontTakeDamage)
 			{
 				npc.dontTakeDamage = true;
 				npc.netUpdate = true;

--- a/Common/GlobalNPCs/NPCTypes/Crimson/BloodCrawler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/BloodCrawler.cs
@@ -61,12 +61,12 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
 
         public void BloodCrawlerAI(NPC npc, Player target)
         {
-            /*if (ExtraAI[1] == 1 && npc.NPCCanStickToWalls())
+            if (ExtraAI[1] == 1 && npc.NPCCanStickToWalls())
             {
                 npc.Transform(NPCID.BloodCrawlerWall);
                 ExtraAI[1] = 0;
                 return;
-            }*/
+            }
             ExtraAI[1] = 0;
 
             if (target == null)

--- a/Common/GlobalNPCs/NPCTypes/Crimson/BloodCrawler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/BloodCrawler.cs
@@ -10,6 +10,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
 {
     public partial class Fighters
     {
+        private static Asset<Texture2D> BloodCrawler_Pounce;
         const float bloodCrawlerAttackMaxBlockDistanceX = 20f;
         const float bloodCrawlerAttackMaxBlockDistanceY = 4f;
         const int bloodCrawlerChargeUpTime = 70;
@@ -23,7 +24,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             {
                 Asset<Texture2D> pounce = ModContent.Request<Texture2D>("TerrariaCells/Common/Assets/BloodcrawlerPounce");
                 spriteBatch.Draw(
-                    pounce.Value,
+                    BloodCrawler_Pounce.Value,
                     npc.position - screenPos,
                     new Rectangle(0, (int)CustomFrameY * 40 + 2, 66, 38),
                     drawColor,

--- a/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
@@ -13,15 +13,13 @@ using System.Reflection;
 using Terraria.DataStructures;
 using MonoMod.Cil;
 using Mono.Cecil.Cil;
-
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 using TerrariaCells.Common.GlobalItems;
 using Terraria.ModLoader.IO;
 using System.IO;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-	public class BrainOfCthulhu : GlobalNPC, Shared.PreFindFrame.IGlobal
+	public class BrainOfCthulhu : GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 	{
         public static Vector2? SpawnPos { get; internal set; } = null;
 

--- a/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
@@ -111,8 +111,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
                 return;
             }
 
-            npc.localAI[1] = SpawnPos.Value.X;
-            npc.localAI[2] = SpawnPos.Value.Y;
+            npc.localAI[1] = npc.Center.X;
+            npc.localAI[2] = npc.Center.Y;
         }
 
         //This is probably not ideal NPC behaviour code

--- a/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/BrainOfCthulhu.cs
@@ -23,7 +23,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
 	public class BrainOfCthulhu : GlobalNPC, Shared.PreFindFrame.IGlobal
 	{
-        internal static Vector2? SpawnPos { get; private set; } = null;
+        public static Vector2? SpawnPos { get; internal set; } = null;
 
         public override void Load()
 		{
@@ -105,9 +105,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 
             if (SpawnPos is null)
             {
-                npc.EncourageDespawn(0);
+                npc.EncourageDespawn(-1);
                 npc.timeLeft = 0;
-                SpawnPos = npc.Center;
+                SpawnPos = npc.position + (Vector2.UnitX * 80);
                 PowerupPickups.brainOfCthuluSpawnPoint = SpawnPos;
                 npc.Opacity = 0;
                 return;
@@ -121,8 +121,16 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
         //Probably don't emulate this
         public override bool PreAI(NPC npc)
 		{
-            if (npc.despawnEncouraged)
+            if (SpawnPos is null)
+            {
+                npc.EncourageDespawn(-1);
+                npc.netUpdate = true;
                 return false;
+            }
+            if (npc.despawnEncouraged)
+            {
+                return false;
+            }
 
             int timer = (int)npc.ai[0];
 

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Crimera.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Crimera.cs
@@ -8,10 +8,11 @@ using static TerrariaCells.Common.Utilities.NPCHelpers;
 using Microsoft.Xna.Framework.Graphics;
 
 using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
+using Terraria.ModLoader;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-	public class Crimera : Terraria.ModLoader.GlobalNPC
+	public class Crimera : Terraria.ModLoader.GlobalNPC, OnAnyPlayerHit.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type is NPCID.Crimera or NPCID.BigCrimera or NPCID.LittleCrimera or NPCID.EaterofSouls or NPCID.LittleEater or NPCID.BigEater;
 
@@ -179,7 +180,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 			{
 				CombatNPC.ToggleContactDamage(npc, false);
 			}
-			if (timer > 45)
+			if (timer > 35)
 			{
 				npc.ai[1] = Idle;
 				npc.ai[0] = 0;
@@ -198,5 +199,18 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 			}
 			return base.PreDraw(npc, spritebatch, screenPos, lightColor);
 		}
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case Stun:
+                        npc.ai[0] = 0;
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Crimslime.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Crimslime.cs
@@ -7,14 +7,13 @@ using Terraria.ModLoader;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using TerrariaCells.Common.Utilities;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using static TerrariaCells.Common.Utilities.NumberHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-	public class Crimslime : Terraria.ModLoader.GlobalNPC, Shared.PreFindFrame.IGlobal
+	public class Crimslime : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
@@ -110,7 +109,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 				return;
 			}
 
-			if (npc.ai[0] == 0)
+            CombatNPC.ToggleContactDamage(npc, false);
+
+            if (npc.ai[0] == 0)
 			{
 				npc.ai[2] = Main.rand.NextDirection();
 				npc.netUpdate = true;

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Crimslime.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Crimslime.cs
@@ -13,7 +13,7 @@ using static TerrariaCells.Common.Utilities.NumberHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-	public class Crimslime : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
+	public class Crimslime : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
@@ -296,5 +296,19 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 
 			return base.PreDraw(npc, spritebatch, screenPos, lightColor);
 		}
-	}
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case Lunge:
+                        npc.ai[0] = MathF.Max(npc.ai[0]-8, 0);
+                        npc.velocity.X *= 0.5f;
+                        break;
+                }
+            }
+        }
+    }
 }

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+
+using Microsoft.Xna.Framework;
+
+using TerrariaCells.Common.Utilities;
+using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
+
+using static TerrariaCells.Common.Utilities.NPCHelpers;
+using static TerrariaCells.Common.Utilities.NumberHelpers;
+using Terraria.DataStructures;
+
+namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
+{
+    public class Drippler : GlobalNPC
+    {
+        public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.Drippler;
+
+        public override bool PreAI(NPC npc)
+        {
+            if (npc.ai[0] == 0)
+                FloatAI(npc);
+            else
+                KilledAI(npc);
+
+            return false;
+        }
+
+        private void FloatAI(NPC npc)
+        {
+            npc.ai[1] = MathF.Sign(npc.velocity.X);
+            if (npc.ai[1] == 0)
+                npc.ai[1] = 1;
+
+            npc.velocity.X = MathHelper.Lerp(npc.velocity.X, npc.ai[1] * 0.8f, 0.05f);
+            if (npc.collideX)
+            {
+                npc.velocity.X *= -1;
+            }
+            npc.direction = MathF.Sign(npc.velocity.X);
+
+            const int GROUND_DISTANCE = 5;
+            Vector2 ground = npc.FindGroundInFront(GROUND_DISTANCE);
+            if (ground.Y < npc.position.Y + ((GROUND_DISTANCE - 1) * 16))
+            {
+                npc.ai[2] = 25;
+                npc.velocity.Y -= 0.04f;
+            }
+            if (npc.ai[2] > 0)
+            {
+                npc.ai[2]--;
+                npc.velocity.Y -= 0.03f;
+            }
+            else
+            {
+                npc.velocity.Y += 0.02f;
+            }
+            npc.velocity.Y = MathF.Min(MathF.Abs(npc.velocity.Y), 0.8f) * MathF.Sign(npc.velocity.Y);
+        }
+        private void KilledAI(NPC npc)
+        {
+            npc.velocity.Y += 0.14f;
+            npc.rotation += npc.velocity.X;
+            npc.ai[0]++;
+
+            if (npc.ai[0] > 45 && Main.netMode != NetmodeID.MultiplayerClient)
+            {
+                npc.StrikeInstantKill();
+            }
+        }
+
+        public override bool CheckDead(NPC npc)
+        {
+            npc.dontTakeDamage = true;
+            npc.life = 1;
+            npc.ai[0] = MathF.Max(npc.ai[0], 1);
+            return npc.ai[0] > 45;
+        }
+        public override bool PreKill(NPC npc)
+        {
+            return npc.ai[0] > 1;
+        }
+        public override void OnKill(NPC npc)
+        {
+            Projectile.NewProjectile(npc.GetSource_Death(), npc.Center, Vector2.Zero, ModContent.ProjectileType<DripplerExplosion>(), npc.damage, 1f, Main.myPlayer);
+        }
+        public override void OnSpawn(NPC npc, IEntitySource source)
+        {
+            CombatNPC.ToggleContactDamage(npc, true);
+        }
+    }
+
+    public class DripplerExplosion : ModProjectile
+    {
+        public override string Texture => $"Terraria/Images/Projectile_{ProjectileID.None}";
+
+        public override void SetDefaults()
+        {
+            Projectile.hostile = true;
+            Projectile.penetrate = -1;
+            Projectile.timeLeft = 1;
+            Projectile.tileCollide = false;
+            Projectile.width = 120;
+            Projectile.height = 120;
+        }
+        public override void OnSpawn(IEntitySource source)
+        {
+            //Projectile.position -= (Projectile.Size * 0.5f);
+
+            for (int i = 0; i < 8 + Main.rand.Next(8); i++)
+            {
+                Vector2 spawnPos = Projectile.Center + (Vector2.UnitX.RotatedByRandom(MathHelper.TwoPi) * Projectile.Size.X * 0.33f);
+                Vector2 vel = (spawnPos - Projectile.Center).SafeNormalize(Vector2.Zero);
+
+                for (int j = 0; j < Main.rand.Next(3, 5); j++)
+                {
+                    Dust dust = Dust.NewDustDirect(spawnPos, 1, 1, DustID.Blood);
+                    dust.rotation = Main.rand.NextFloat(MathHelper.TwoPi);
+                    dust.scale = Main.rand.NextFloat(1.2f, 1.5f);
+                    dust.velocity = vel * (j+4) * 0.5f;
+                    dust.noGravity = false;
+                }
+            }
+        }
+    }
+}

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
@@ -17,7 +17,7 @@ using Terraria.DataStructures;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-    public class Drippler : GlobalNPC
+    public class Drippler : GlobalNPC, Shared.PreHitEffect.IGlobal
     {
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.Drippler;
 
@@ -74,6 +74,12 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
             }
         }
 
+        public bool PreHitEffect(NPC npc, int dir, double dmg, bool instant)
+        {
+            if (npc.ai[0] < 45)
+                return false;
+            return true;
+        }
         public override bool CheckDead(NPC npc)
         {
             npc.dontTakeDamage = true;
@@ -83,7 +89,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
         }
         public override bool PreKill(NPC npc)
         {
-            return npc.ai[0] > 1;
+            bool dies = npc.ai[0] > 45 && npc.dontTakeDamage;
+            if (!dies)
+                npc.life = 1;
+            return dies;
         }
         public override void OnKill(NPC npc)
         {

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
@@ -32,11 +32,19 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 
         private void FloatAI(NPC npc)
         {
+            float maxSpeed = 0.8f;
+
             npc.ai[1] = MathF.Sign(npc.velocity.X);
             if (npc.ai[1] == 0)
                 npc.ai[1] = 1;
+            npc.TargetClosest(false);
+            if (npc.TryGetTarget(out Entity target) && npc.TargetInAggroRange(target, 560, false))
+            {
+                npc.ai[1] = MathF.Sign(target.position.X - npc.position.X);
+                maxSpeed *= 1.5f;
+            }
 
-            npc.velocity.X = MathHelper.Lerp(npc.velocity.X, npc.ai[1] * 0.8f, 0.05f);
+            npc.velocity.X = MathHelper.Lerp(npc.velocity.X, npc.ai[1] * maxSpeed, 0.05f);
             if (npc.collideX)
             {
                 npc.velocity.X *= -1;

--- a/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
+++ b/Common/GlobalNPCs/NPCTypes/Crimson/Drippler.cs
@@ -9,7 +9,6 @@ using Terraria.ID;
 using Microsoft.Xna.Framework;
 
 using TerrariaCells.Common.Utilities;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using static TerrariaCells.Common.Utilities.NumberHelpers;
@@ -17,7 +16,7 @@ using Terraria.DataStructures;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Crimson
 {
-    public class Drippler : GlobalNPC, Shared.PreHitEffect.IGlobal
+    public class Drippler : GlobalNPC, Common.GlobalNPCs.PreHitEffect.IGlobal
     {
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.Drippler;
 

--- a/Common/GlobalNPCs/NPCTypes/Desert/Ghoul.cs
+++ b/Common/GlobalNPCs/NPCTypes/Desert/Ghoul.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria;
 using Terraria.Audio;
+using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/Common/GlobalNPCs/NPCTypes/Desert/Mummy.cs
+++ b/Common/GlobalNPCs/NPCTypes/Desert/Mummy.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria;
 using Terraria.Audio;
+using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;

--- a/Common/GlobalNPCs/NPCTypes/Desert/SandPoacher.cs
+++ b/Common/GlobalNPCs/NPCTypes/Desert/SandPoacher.cs
@@ -172,6 +172,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             //stab
             if (npc.ai[3] == 2)
             {
+                CombatNPC.ToggleContactDamage(npc, true);
                 ShouldWalk = false;
                 npc.velocity.X *= 0.9f;
                 npc.direction = npc.oldDirection;
@@ -190,6 +191,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
 
                 if (ExtraAI[0] > stabTime)
                 {
+                    CombatNPC.ToggleContactDamage(npc, false);
                     npc.ai[3] = 3;
                     ExtraAI[0] = 0;
                     CustomFrameCounter = 0;
@@ -200,6 +202,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             //wait
             if (npc.ai[3] == 3)
             {
+                CombatNPC.ToggleContactDamage(npc, false);
                 ShouldWalk = false;
                 npc.velocity.X *= 0.9f;
                 npc.direction = npc.oldDirection;

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
@@ -1,0 +1,342 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Terraria;
+using Terraria.ModLoader;
+using Terraria.ID;
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using TerrariaCells.Common.Utilities;
+using static TerrariaCells.Common.Utilities.NPCHelpers;
+using static TerrariaCells.Common.Utilities.PlayerHelpers;
+
+namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
+{
+    public class SkeletonSniper : GlobalNPC, Shared.PreFindFrame.IGlobal
+    {
+        public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.SkeletonSniper;
+
+        const int Idle = 0;
+        const int FollowPlayer = 1;
+        const int Shoot = 2;
+        const int Reload = 3;
+
+        public override bool PreAI(NPC npc)
+        {
+            switch ((int)npc.ai[1])
+            {
+                case Idle:
+                    IdleAI(npc);
+                    break;
+                case FollowPlayer:
+                    FollowPlayerAI(npc);
+                    break;
+                case Shoot:
+                    ShootAI(npc);
+                    break;
+                case Reload:
+                    ReloadAI(npc);
+                    break;
+            }
+            return false;
+        }
+
+        const float MaxSpeed = 1.4f;
+        const float Accel = 0.1f;
+        private void IdleAI(NPC npc)
+        {
+            npc.TargetClosest(false);
+            if (npc.TargetInAggroRange(NumberHelpers.ToTileDist(22)))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = FollowPlayer;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            npc.direction = MathF.Sign(npc.velocity.X);
+
+            float newVel = npc.velocity.X + npc.direction * Accel;
+            if (npc.direction == 0)
+            {
+                newVel = npc.velocity.X + npc.spriteDirection * Accel;
+                npc.direction = MathF.Sign(newVel);
+            }
+            if (MathF.Abs(newVel) < MaxSpeed)
+                npc.velocity.X = newVel;
+            else
+                npc.velocity.X = MathF.Sign(npc.velocity.X) * MaxSpeed;
+
+            if (npc.collideX)
+            {
+                Vector2 oldPos = npc.position;
+                Vector2 oldVel = npc.velocity;
+                Collision.StepUp(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY);
+                if (npc.position.Equals(oldPos))
+                {
+                    npc.position -= npc.oldVelocity * 2;
+                    npc.ai[0] = 0;
+                    npc.ai[1] = Idle;
+                    npc.ai[2] = -npc.direction;
+                    npc.ai[3] = 0;
+                    return;
+                }
+                else
+                {
+                    if (MathF.Abs(npc.velocity.X) < MathF.Abs(oldVel.X))
+                    {
+                        npc.velocity.X = (npc.velocity.X + oldVel.X) * 0.5f;
+                    }
+                    npc.ai[0] -= 3;
+                }
+            }
+
+            Vector2 nextGround = npc.FindGroundInFront();
+            if (npc.Grounded() && nextGround.Y > npc.Bottom.Y + npc.height)
+            {
+                npc.velocity.X *= 0.5f;
+                npc.ai[0] = 0;
+                npc.ai[1] = Idle;
+                npc.ai[2] = -npc.direction;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            if (npc.ai[0] > 240)
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = Idle;
+                npc.ai[2] = -npc.direction;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            npc.velocity.Y += 0.036f; //Apply gravity
+            npc.ai[0]++;
+        }
+        private void FollowPlayerAI(NPC npc)
+        {
+            npc.TargetClosest(true);
+            if (!npc.TryGetTarget(out Entity target))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = Idle;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+            if (npc.TargetInAggroRange(target, 640f, true, false))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = Shoot;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+            Vector2 nextGround = npc.FindGroundInFront();
+            if (npc.Grounded() && nextGround.Y > npc.Bottom.Y + npc.height)
+            {
+                npc.position.X -= npc.velocity.X;
+                npc.velocity.X = 0;
+                return;
+            }
+
+            if (npc.TargetInAggroRange(target, 700, false))
+            {
+                int direction = target.position.X < npc.position.X ? -1 : 1;
+
+                float newVel = npc.velocity.X + direction * Accel;
+                if (MathF.Abs(newVel) < MaxSpeed)
+                    npc.velocity.X = newVel;
+                else
+                    npc.velocity.X = MathF.Sign(npc.velocity.X) * MaxSpeed;
+            }
+
+            npc.velocity.Y += 0.036f;
+        }
+        private void ShootAI(NPC npc)
+        {
+            if (!npc.TryGetTarget(out Entity target))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = Idle;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+            npc.direction = target.position.X < npc.position.X ? -1 : 1;
+            npc.spriteDirection = npc.direction;
+            if (npc.TargetInAggroRange(target, 640f, true, false) && npc.ai[0] < 101)
+            {
+                npc.ai[0]++;
+
+                float rotation = (target.Center - npc.Center).ToRotation();
+                npc.ai[3] = rotation;
+            }
+            else if (npc.ai[0] > 80)
+            {
+                npc.ai[0]++;
+            }
+            else if (npc.ai[0] > 0)
+            {
+                npc.ai[0] -= 0.4f;
+            }
+            else
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = FollowPlayer;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            if (npc.ai[0] > 105)
+            {
+                if (Main.netMode != 1)
+                {
+                    Vector2 vel = Vector2.UnitX.RotatedBy(npc.ai[3]) * 14f;
+                    Projectile proj = Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Center, vel, ProjectileID.SniperBullet, TCellsUtils.ScaledHostileDamage(npc.damage), 1f, Main.myPlayer);
+                }
+
+                npc.ai[0] = 0;
+                npc.ai[1] = Reload;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            npc.velocity.X *= 0.9f;
+            npc.velocity.Y += 0.036f;
+        }
+        private void ReloadAI(NPC npc)
+        {
+            npc.ai[0]++;
+            if (npc.ai[0] > 45)
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = Idle;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+            }
+
+            npc.velocity.X *= 0.9f;
+            npc.velocity.Y += 0.036f;
+        }
+
+        public bool PreFindFrame(NPC npc, int frameHeight)
+        {
+            int frameNum = npc.frame.Y / frameHeight;
+            switch ((int)npc.ai[1])
+            {
+                //Mostly borrowed framing code from Goblin Archer, actually
+                case Idle:
+                case FollowPlayer:
+                    npc.frameCounter += (int)(npc.velocity.X);
+                    if (Math.Abs(npc.frameCounter) > 4)
+                    {
+                        const int Offset = 7;
+                        int frameCount = Main.npcFrameCount[npc.type];
+                        int cFrame = npc.frame.Y / frameHeight;
+                        frameNum = cFrame + Math.Sign(npc.frameCounter * npc.spriteDirection);
+                        frameNum = Offset + (((frameNum - Offset) + (frameCount - Offset)) % (frameCount - Offset));
+                        npc.frameCounter = 0;
+                    }
+                    break;
+                case Shoot:
+                    float rotation = npc.ai[3];
+                    rotation = (rotation + MathHelper.TwoPi) % MathHelper.TwoPi;
+
+                    if (rotation > MathHelper.PiOver2 && rotation < 3 * MathHelper.PiOver2)
+                    {
+                        rotation -= MathHelper.PiOver2; //0-Pi
+                    }
+                    else
+                    {
+                        //Range from -Pi/2 - Pi/2
+                        if (rotation > MathHelper.Pi) //3Pi/2 - 2Pi
+                            rotation -= MathHelper.TwoPi; //-Pi/2 - 0
+                        rotation += MathHelper.PiOver2; //0 - Pi/2 + Pi/2 - Pi
+                        rotation = MathHelper.Pi - rotation;
+                    }
+                    //rotation now from 0-Pi
+                    float mult = rotation / MathHelper.Pi;
+                    frameNum = (int)MathHelper.Clamp(mult * 5, 0, 5);
+                    break;
+                case Reload:
+                    frameNum = 1;
+                    break;
+            }
+            npc.frame.Y = frameNum * frameHeight;
+            return false;
+        }
+        public override void PostDraw(NPC npc, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
+        {
+            if (npc.ai[1] == Shoot)
+            {
+                if(!npc.TryGetTarget(out Entity target)) return;
+                if(npc.ai[0] <= 0) return;
+
+                Color lineColor = Color.Red * 0.67f;
+                if (npc.ai[0] > 90)
+                    return;
+                else if (npc.ai[0] > 60)
+                {
+                    lineColor = Color.Lerp(lineColor, Color.Orange * 0.9f, (npc.ai[0] - 60) / 30f);
+                }
+                else if ((int)(npc.ai[0]) % 8 > 4)
+                    lineColor = Color.Transparent;
+
+                float width = 2;
+                if (npc.ai[0] < 30)
+                    width = 12f - (npc.ai[0] / 30 * 10f);
+                else if (npc.ai[0] > 60)
+                    width = 1;
+
+                Vector2 startPos = npc.Center + (Vector2.UnitX * npc.spriteDirection * 12);
+                Vector2 direction = Vector2.UnitX.RotatedBy(npc.ai[3]);
+                Vector2 targetPos = startPos;
+                for (int i = 0; i < 32; i++)
+                {
+                    targetPos += direction * 16;
+                    if (!Collision.CanHitLine(startPos, 2, 2, targetPos, 2, 2)
+                        || (target.DistanceSQ(npc.Center) > 6400
+                        && new Rectangle((int)target.position.X, (int)target.position.Y, target.width, target.height).Contains(targetPos.ToPoint())))
+                        break;
+                }
+                float visualTimer = (float)(Main.timeForVisualEffects + (npc.whoAmI * 10)) * 0.15f;
+                float inaccuracy = 1 - (npc.ai[0] / 70f);
+                if (inaccuracy > 0)
+                    targetPos += new Vector2(MathF.Cos(visualTimer) * target.width, MathF.Sin(visualTimer) * target.height) * 0.5f * inaccuracy;
+                Terraria.Utils.DrawLine(spriteBatch, startPos, targetPos, lineColor, lineColor * 0.75f, width);
+            }
+        }
+
+        //Hitstun
+        public override void OnHitByItem(NPC npc, Player player, Item item, NPC.HitInfo hit, int damageDone)
+        {
+            if (hit.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                if (npc.ai[1] == Shoot || npc.ai[1] == Reload)
+                {
+                    npc.ai[0] -= damageDone / 7f;
+                }
+            }
+        }
+        public override void OnHitByProjectile(NPC npc, Projectile projectile, NPC.HitInfo hit, int damageDone)
+        {
+            if (hit.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                if (npc.ai[1] == Shoot || npc.ai[1] == Reload)
+                {
+                    npc.ai[0] -= damageDone / 7f;
+                }
+            }
+        }
+    }
+}

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
@@ -18,7 +18,7 @@ using Terraria.DataStructures;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
 {
-    public class SkeletonSniper : GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
+    public class SkeletonSniper : GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
     {
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.SkeletonSniper;
 
@@ -321,24 +321,16 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
         }
         public override bool? CanFallThroughPlatforms(NPC npc) => false;
 
-        //Hitstun
-        public override void OnHitByItem(NPC npc, Player player, Item item, NPC.HitInfo hit, int damageDone)
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
         {
-            if (hit.DamageType.CountsAsClass(DamageClass.Melee))
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
             {
-                if (npc.ai[1] == Shoot || npc.ai[1] == Reload)
+                switch ((int)npc.ai[1])
                 {
-                    npc.ai[0] -= damageDone / 7f;
-                }
-            }
-        }
-        public override void OnHitByProjectile(NPC npc, Projectile projectile, NPC.HitInfo hit, int damageDone)
-        {
-            if (hit.DamageType.CountsAsClass(DamageClass.Melee))
-            {
-                if (npc.ai[1] == Shoot || npc.ai[1] == Reload)
-                {
-                    npc.ai[0] -= damageDone / 7f;
+                    case Shoot:
+                    case Reload:
+                        npc.ai[0] -= damage / 6f;
+                        break;
                 }
             }
         }

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
@@ -18,7 +18,7 @@ using Terraria.DataStructures;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
 {
-    public class SkeletonSniper : GlobalNPC, Shared.PreFindFrame.IGlobal
+    public class SkeletonSniper : GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
     {
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.SkeletonSniper;
 

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/SkeletonSniper.cs
@@ -14,6 +14,7 @@ using Microsoft.Xna.Framework.Graphics;
 using TerrariaCells.Common.Utilities;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using static TerrariaCells.Common.Utilities.PlayerHelpers;
+using Terraria.DataStructures;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
 {
@@ -25,6 +26,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
         const int FollowPlayer = 1;
         const int Shoot = 2;
         const int Reload = 3;
+
+        public override void OnSpawn(NPC npc, IEntitySource source) => CombatNPC.ToggleContactDamage(npc, false);
 
         public override bool PreAI(NPC npc)
         {
@@ -316,6 +319,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
                 Terraria.Utils.DrawLine(spriteBatch, startPos, targetPos, lineColor, lineColor * 0.75f, width);
             }
         }
+        public override bool? CanFallThroughPlatforms(NPC npc) => false;
 
         //Hitstun
         public override void OnHitByItem(NPC npc, Player player, Item item, NPC.HitInfo hit, int damageDone)

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinArcher.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinArcher.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using Terraria;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using TerrariaCells.Common.Utilities;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-	public class GoblinArcher : Terraria.ModLoader.GlobalNPC, Shared.PreFindFrame.IGlobal
+	public class GoblinArcher : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
@@ -71,7 +70,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 				return;
 			}
 
-			npc.direction = MathF.Sign(npc.ai[2]);
+            CombatNPC.ToggleContactDamage(npc, false);
+
+            npc.direction = MathF.Sign(npc.ai[2]);
 
 			float newVel = npc.velocity.X + npc.direction * Accel;
 			if (npc.direction == 0)

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinArcher.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinArcher.cs
@@ -2,10 +2,11 @@
 using Terraria;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 using TerrariaCells.Common.Utilities;
+using Terraria.ModLoader;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-	public class GoblinArcher : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
+	public class GoblinArcher : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
@@ -326,5 +327,20 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
         }
 
         public override bool? CanFallThroughPlatforms(NPC npc) => false;
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case FireArrows:
+                        if (npc.ai[0] < 25)
+                            break;
+                        npc.ai[0] = MathF.Max(npc.ai[0] - 10, 25);
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
@@ -64,7 +64,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 				return;
 			}
 
-			npc.dontTakeDamage = true;
+            CombatNPC.ToggleContactDamage(npc, false);
+
+            npc.dontTakeDamage = true;
 			npc.velocity.Y += 0.14f;
 
 			if (Main.rand.NextBool(3))

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinSorcerer.cs
@@ -5,12 +5,14 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria;
 using Terraria.ID;
+using Terraria.ModLoader;
+
 using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-	public class GoblinSorcerer : Terraria.ModLoader.GlobalNPC
+	public class GoblinSorcerer : Terraria.ModLoader.GlobalNPC, OnAnyPlayerHit.IGlobal
 	{
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
@@ -219,5 +221,21 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 		}
 
         public override bool? CanFallThroughPlatforms(NPC npc) => false;
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case Casting:
+                        npc.ai[0] = MathF.Max(npc.ai[0] - 15, 0);
+                        break;
+                    case Teleporting:
+                        npc.ai[0] = MathF.Max(npc.ai[0] - 5, 0);
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinThief.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinThief.cs
@@ -3,12 +3,13 @@
 using System;
 
 using Terraria;
+using Terraria.ModLoader;
 
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-	public class GoblinThief : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
+	public class GoblinThief : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
 	{
         private static ReLogic.Content.Asset<Texture2D> goblin_StabSprite;
         public override void Load()
@@ -337,5 +338,24 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
         }
 
         public override bool? CanFallThroughPlatforms(NPC npc) => npc.stairFall;
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case Stab:
+                        npc.ai[0] = Stun_Delay * 0.5f;
+                        npc.ai[1] = Stun;
+                        npc.ai[2] = 0;
+                        npc.ai[3] = 0;
+                        break;
+                    case Stun:
+                        npc.ai[0] = MathF.Max(npc.ai[0] - 5, 0);
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Forest/GoblinThief.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/GoblinThief.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+
 using System;
+
 using Terraria;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
+
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-	public class GoblinThief : Terraria.ModLoader.GlobalNPC, Shared.PreFindFrame.IGlobal
+	public class GoblinThief : Terraria.ModLoader.GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 	{
         private static ReLogic.Content.Asset<Texture2D> goblin_StabSprite;
         public override void Load()
@@ -15,7 +17,6 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
             {
                 goblin_StabSprite = Terraria.ModLoader.ModContent.Request<Texture2D>("TerrariaCells/Common/Assets/GoblinStab");
             }
-            base.Load();
         }
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == Terraria.ID.NPCID.GoblinThief;
         //public override bool AppliesToNPC(int npcType)
@@ -81,6 +82,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
                 npc.ai[1] = ApproachTarget;
 				return;
 			}
+
+            CombatNPC.ToggleContactDamage(npc, false);
 
 			npc.direction = MathF.Sign(npc.ai[3]);
 			float newVel = npc.velocity.X + npc.direction * Accel;
@@ -151,7 +154,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
                 return;
 			}
 
-			npc.direction = npc.velocity.X < 0 ? -1 : 1;
+            CombatNPC.ToggleContactDamage(npc, false);
+
+            npc.direction = npc.velocity.X < 0 ? -1 : 1;
 			Vector2 distance = new Vector2(MathF.Abs(target.position.X - npc.position.X), MathF.Abs(target.position.Y - npc.position.Y));
 			if (
 				npc.IsFacingTarget(target)
@@ -324,6 +329,7 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
             if (npc.ai[1] >= Stab)
             {
                 Vector2 size = goblin_StabSprite.Size();
+                lightColor = npc.GetNPCColorTintedByBuffs(lightColor);
                 spritebatch.Draw(goblin_StabSprite.Value, npc.Top - screenPos, npc.frame with { Width = (int)size.X, Height = (int)(size.Y / 6) } , lightColor, 0, new Vector2(size.X*0.5f, 8), npc.scale, npc.spriteDirection != 1 ? SpriteEffects.None : SpriteEffects.FlipHorizontally, 0);
                 return false;
             }

--- a/Common/GlobalNPCs/NPCTypes/Forest/Wolf.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/Wolf.cs
@@ -59,6 +59,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
                 npc.ai[1] = IdleTarget;
                 return;
             }
+
+            CombatNPC.ToggleContactDamage(npc, false);
+
             if (MathF.Abs(npc.ai[3]) == 0)
                 npc.ai[3] = 1;
             npc.direction = (int)npc.ai[3];

--- a/Common/GlobalNPCs/NPCTypes/Forest/Wolf.cs
+++ b/Common/GlobalNPCs/NPCTypes/Forest/Wolf.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using Terraria;
+using Terraria.ModLoader;
+
 using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
 using static TerrariaCells.Common.Utilities.NPCHelpers;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
 {
-    public class Wolf : Terraria.ModLoader.GlobalNPC//, Shared.PreFindFrame.IGlobal
+    public class Wolf : Terraria.ModLoader.GlobalNPC, PreFindFrame.IGlobal, OnAnyPlayerHit.IGlobal
     {
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == Terraria.ID.NPCID.Wolf;
         //public override bool AppliesToNPC(int npcType)
@@ -304,5 +306,18 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Forest
         }
 
         public override bool? CanFallThroughPlatforms(NPC npc) => npc.stairFall;
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case Approach:
+                        npc.ai[0] = MathF.Max(npc.ai[0] - 5, 0);
+                        break;
+                }
+            }
+        }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
+++ b/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+using TerrariaCells.Common.Utilities;
+
+namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
+{
+    public class Hornet : GlobalNPC
+    {
+        private static readonly int[] HORNETS = new int[]
+        {
+            NPCID.Hornet, NPCID.HornetFatty, NPCID.HornetHoney, NPCID.HornetLeafy,
+            NPCID.HornetSpikey, NPCID.HornetStingy, NPCID.MossHornet
+        };
+        public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
+        {
+            return HORNETS.Contains(entity.type);
+        }
+
+        public override bool PreAI(NPC npc)
+        {
+            switch ((int)npc.ai[1])
+            {
+                case 0:
+                    IdleAI(npc);
+                    break;
+                case 1:
+                    MoveAI(npc);
+                    break;
+                case 2:
+                    ShootAI(npc);
+                    break;
+                case 3:
+                    JabAI(npc);
+                    break;
+            }
+            return false;
+        }
+
+        private void IdleAI(NPC npc)
+        {
+            npc.TargetClosest(false);
+            if (npc.TryGetTarget(out Entity target) && npc.TargetInAggroRange(target, 512))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = 1;
+                npc.ai[2] = -MathF.Sign(npc.position.X - target.position.X);
+                npc.ai[3] = 0;
+                return;
+            }
+
+            Vector2 movePos = new Vector2(npc.ai[2], npc.ai[3]);
+
+            if (movePos.X == 0 || movePos.Y == 0)
+            {
+                if (Main.netMode == NetmodeID.MultiplayerClient)
+                    return;
+
+                for (int i = 0; i < 15; i++)
+                {
+                    movePos = npc.position;
+                    Vector2 direction = Vector2.UnitX.RotatedByRandom(MathHelper.TwoPi);
+
+                    int iterations = 0;
+                    while (Collision.CanHitLine(npc.position, npc.width, npc.height, movePos, npc.width, npc.height) && iterations < 6)
+                    {
+                        movePos += direction * 24;
+                        iterations++;
+                    }
+                    movePos -= direction * 24;
+                    if (iterations > 2)
+                        break;
+                }
+                npc.ai[2] = movePos.X;
+                npc.ai[3] = movePos.Y;
+                npc.netUpdate = true;
+                return;
+            }
+
+            if (movePos.X - npc.position.X != 0)
+                npc.velocity.X += MathF.Sign(movePos.X - npc.position.X) * MathF.Sqrt(MathF.Abs(movePos.X - npc.position.X)) * 0.005f;
+
+            npc.velocity.Y += (movePos.Y < npc.position.Y ? -1 : 1) * 0.024f;
+
+            Collision.StepUp(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY);
+
+            npc.rotation = MathHelper.ToRadians(npc.velocity.X) * 4.5f;
+            npc.direction = MathF.Sign(npc.velocity.X);
+            npc.spriteDirection = npc.direction;
+
+            //Dust.NewDustDirect(movePos, 1, 1, DustID.GemDiamond).velocity = Vector2.Zero;
+
+            if (npc.DistanceSQ(movePos) < 40 * 40)
+            {
+                npc.ai[0]++;
+                npc.velocity *= 0.98f;
+            }
+            else if (npc.ai[0] > 0)
+            {
+                npc.ai[0] -= 0.33f;
+            }
+            if (npc.ai[0] > 80 || !Collision.CanHitLine(npc.position, npc.width, npc.height, movePos, npc.width, npc.height))
+            {
+                npc.ai[0] = 0;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+        }
+
+        private void MoveAI(NPC npc)
+        {
+            npc.TargetClosest(false);
+            if (!npc.TryGetTarget(out Entity target) || !npc.TargetInAggroRange(target, 550, false))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = 0;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            Vector2 movePos = target.Center;
+            movePos.X += npc.ai[2] * 56;
+            movePos.Y -= 112;
+            //Dust.NewDustDirect(movePos, 1, 1, DustID.GemDiamond).velocity = Vector2.Zero;
+
+            if (movePos.X - npc.position.X != 0 && MathF.Abs(npc.velocity.X) < 4f)
+                npc.velocity.X += MathF.Sign(movePos.X - npc.position.X) * MathF.Sqrt(MathF.Abs(movePos.X - npc.position.X)) * 0.045f;
+
+            npc.velocity.Y += (movePos.Y < npc.position.Y ? -1 : 1) * 0.06f;
+
+            if (MathF.Sign(movePos.X - npc.position.X) != MathF.Sign(npc.velocity.X))
+            {
+                npc.velocity.X *= 0.95f;
+            }
+            if (MathF.Sign(movePos.Y - npc.position.Y) != MathF.Sign(npc.velocity.Y))
+            {
+                npc.velocity.Y *= 0.95f;
+            }
+
+            Collision.StepUp(ref npc.position, ref npc.velocity, npc.width, npc.height, ref npc.stepSpeed, ref npc.gfxOffY);
+
+            npc.rotation = MathHelper.ToRadians(npc.velocity.X) * 4.5f;
+            npc.direction = -(int)npc.ai[2];
+            npc.spriteDirection = npc.direction;
+
+
+
+            bool isGoodX = MathF.Abs(npc.position.X - movePos.X) < 48 || npc.collideX;
+            bool isGoodY = MathF.Abs(npc.position.Y - movePos.Y) < 48 || npc.collideY;
+            if (isGoodX && isGoodY)
+            {
+                npc.ai[0]++;
+                npc.velocity *= 0.975f;
+                if (npc.ai[0] > 45)
+                {
+                    npc.ai[0] = 0;
+                    npc.ai[1] = 2;
+                    npc.ai[2] = 0;
+                    npc.ai[3] = 0;
+                }
+            }
+        }
+
+        private void ShootAI(NPC npc)
+        {
+            if (!npc.TryGetTarget(out Entity target) || !npc.TargetInAggroRange(target, 520, false))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = 0;
+                npc.ai[2] = 0;
+                npc.ai[3] = 0;
+                return;
+            }
+
+            if (npc.velocity.Y > -1.6f)
+                npc.velocity.Y -= 0.03f;
+            else
+                npc.velocity.Y *= 0.9f;
+            npc.velocity.X *= 0.9f;
+
+            npc.ai[0]++;
+            if (npc.ai[0] < (24 * 3) && (int)(npc.ai[0]) % 24 == 0 && Main.netMode != NetmodeID.MultiplayerClient)
+            {
+                Vector2 vel = npc.DirectionTo(target.Center) * 6.75f;
+                Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Bottom, vel, ProjectileID.Stinger, TCellsUtils.ScaledHostileDamage(npc.damage), 1f, Main.myPlayer);
+            }
+
+            npc.direction = MathF.Sign(target.position.X - npc.position.X);
+            npc.spriteDirection = npc.direction;
+            npc.rotation = 0;
+
+            if (npc.ai[0] > (24 * 3.5f))
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = 3;
+                npc.ai[2] = MathF.Sign(target.position.X - npc.position.X) * MathF.Sqrt(MathF.Abs(target.position.X - npc.position.X)) * 0.0425f;
+                npc.ai[3] = 0;
+                return;
+            }
+        }
+
+        private void JabAI(NPC npc)
+        {
+            if (npc.TryGetTarget(out Entity target))
+            {
+                npc.ai[2] = MathF.Sign(target.position.X - npc.position.X) * MathF.Sqrt(MathF.Abs(target.position.X - npc.position.X)) * 0.0425f;
+            }
+
+            if (npc.collideY && npc.oldVelocity.Y > 0 || npc.ai[3] > 0)
+            {
+                npc.velocity *= 0;
+                npc.ai[3]++;
+            }
+            if (npc.ai[3] > 24)
+            {
+                npc.velocity *= 0.95f;
+            }
+            else if (npc.ai[3] > 6)
+            {
+                npc.velocity.Y = -6;
+                npc.velocity.X = -npc.ai[2] * 4f;
+            }
+            else if (npc.ai[0] > 25)
+            {
+                npc.velocity.Y = 6;
+                npc.velocity.X += npc.ai[2];
+            }
+            else
+            {
+                npc.velocity *= 0.95f;
+                npc.velocity.Y *= 0.95f;
+            }
+
+            CombatNPC.ToggleContactDamage(npc, npc.ai[0] > 25 && npc.ai[3] < 1);
+
+            npc.rotation = -MathHelper.ToRadians(npc.velocity.X) * 2.8f;
+            npc.direction = MathF.Sign(npc.ai[2]);
+            npc.spriteDirection = npc.direction;
+
+            npc.ai[0]++;
+
+            if (npc.ai[3] > 36)
+            {
+                npc.ai[0] = 0;
+                npc.ai[1] = 1;
+                npc.ai[2] = -MathF.Sign(npc.ai[2]);
+                npc.ai[3] = 0;
+                return;
+            }
+        }
+
+        public override void OnSpawn(NPC npc, IEntitySource source)
+        {
+            CombatNPC.ToggleContactDamage(npc, false);
+        }
+    }
+}

--- a/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
+++ b/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
@@ -57,6 +57,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
                 return;
             }
 
+            CombatNPC.ToggleContactDamage(npc, false);
+
             Vector2 movePos = new Vector2(npc.ai[2], npc.ai[3]);
 
             if (movePos.X == 0 || movePos.Y == 0)

--- a/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
+++ b/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
@@ -13,7 +13,7 @@ using TerrariaCells.Common.Utilities;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
 {
-    public class Hornet : GlobalNPC
+    public class Hornet : GlobalNPC, OnAnyPlayerHit.IGlobal
     {
         private static readonly int[] HORNETS = new int[]
         {
@@ -264,6 +264,22 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
         public override void OnSpawn(NPC npc, IEntitySource source)
         {
             CombatNPC.ToggleContactDamage(npc, false);
+        }
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo info, int damage)
+        {
+            if (info.DamageType.CountsAsClass(DamageClass.Melee))
+            {
+                switch ((int)npc.ai[1])
+                {
+                    case 2:
+                        npc.ai[0] = 0;
+                        npc.ai[1] = 3;
+                        npc.ai[2] = MathF.Sign(attacker.position.X - npc.position.X) * MathF.Sqrt(MathF.Abs(attacker.position.X - npc.position.X)) * 0.0425f;
+                        npc.ai[3] = 0;
+                        break;
+                }
+            }
         }
     }
 }

--- a/Common/GlobalNPCs/NPCTypes/Hive/QueenBee.cs
+++ b/Common/GlobalNPCs/NPCTypes/Hive/QueenBee.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
+
 using ReLogic.Content;
+
 using System;
 using System.IO;
+
 using Terraria;
 using Terraria.Audio;
 using Terraria.GameContent;
@@ -9,14 +12,13 @@ using Terraria.Graphics.CameraModifiers;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
-using TerrariaCells.Common.GlobalNPCs;
-using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
+
 using TerrariaCells.Common.Utilities;
 using TerrariaCells.Content.Projectiles;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive;
 
-public class QueenBee : GlobalNPC, Shared.PreFindFrame.IGlobal
+public class QueenBee : GlobalNPC, Common.GlobalNPCs.PreFindFrame.IGlobal
 {
     public static Vector2 SpawnPosition = Vector2.Zero;
     

--- a/Common/GlobalNPCs/NPCTypes/Shared/Casters.cs
+++ b/Common/GlobalNPCs/NPCTypes/Shared/Casters.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.Utilities;
@@ -122,6 +123,11 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                 return CultistDevoteeAI(npc, target);
             }
             return base.PreAI(npc);
+        }
+
+        public override void OnSpawn(NPC npc, IEntitySource source)
+        {
+            CombatNPC.ToggleContactDamage(npc, false);
         }
 
         //teleport to a random position. teleports near the given position.

--- a/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
+++ b/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
@@ -18,7 +18,7 @@ using Terraria.ModLoader.IO;
 
 namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
 {
-    public partial class Fighters : GlobalNPC
+    public partial class Fighters : GlobalNPC, OnAnyPlayerHit.IGlobal
     {
         public override bool InstancePerEntity => true;
         public int CustomFrameY = 0;
@@ -180,6 +180,14 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                 return false;
             }
             return base.PreAI(npc);
+        }
+
+        public void OnAnyPlayerHit(NPC npc, Player attacker, NPC.HitInfo hit, int damage)
+        {
+            if (npc.type == NPCID.BloodCrawler)
+            {
+                BloodCrawler_OnHit(npc, attacker, hit, damage);
+            }
         }
 
         public override void OnSpawn(NPC npc, IEntitySource source)

--- a/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
+++ b/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 using System.Threading.Tasks;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.GameContent;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -179,6 +180,11 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                 return false;
             }
             return base.PreAI(npc);
+        }
+
+        public override void OnSpawn(NPC npc, IEntitySource source)
+        {
+            CombatNPC.ToggleContactDamage(npc, false);
         }
 
         public override void SendExtraAI(NPC npc, BitWriter bitWriter, BinaryWriter binaryWriter)

--- a/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
+++ b/Common/GlobalNPCs/NPCTypes/Shared/Fighters.cs
@@ -30,6 +30,14 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
         public float Acceleration = 0.1f;
         public float JumpSpeed = 8;
 
+        public override void Load()
+        {
+            if (!Main.dedServ)
+            {
+                Fighters.BloodCrawler_Pounce = ModContent.Request<Texture2D>("TerrariaCells/Common/Assets/BloodcrawlerPounce");
+            }
+        }
+
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
             return Mummies.Contains(entity.type)

--- a/Common/ModPlayers/DeathReset.cs
+++ b/Common/ModPlayers/DeathReset.cs
@@ -54,6 +54,7 @@ public class DeathReset : ModPlayer, IEntitySource
         if (isNewWorld)
         {
             ResetInventory(ResetInventoryContext.NewWorld);
+            Common.GlobalNPCs.NPCTypes.Crimson.BrainOfCthulhu.SpawnPos = null;
         }
 
         if (Main.netMode == NetmodeID.MultiplayerClient)

--- a/Common/Utilities/NPCHelpers.cs
+++ b/Common/Utilities/NPCHelpers.cs
@@ -89,7 +89,7 @@ namespace TerrariaCells.Common.Utilities
 			{
 				Vector2 collision = Collision.TileCollision(testPos, Vector2.UnitY * 16, npc.width, npc.height);
 				if (collision.Y != 16)
-					return testPos  + collision;
+					return testPos + collision;
 			}
 			return testPos + new Vector2(0, tilesToCheck * 16);
 		}

--- a/Localization/en-US_Mods.TerrariaCells.hjson
+++ b/Localization/en-US_Mods.TerrariaCells.hjson
@@ -338,6 +338,7 @@ Projectiles: {
 	BeeWallBee.DisplayName: Bee
 	BeeMissile.DisplayName: Bee Missile
 	BeeMissileBee.DisplayName: Bee
+	DripplerExplosion.DisplayName: Drippler Explosion
 }
 
 Tooltips: {


### PR DESCRIPTION
Add:
- Dripplers (amiably float around, will hunt down player if nearby, explodes after a short delay on death)
- Hornets (aggressively tracks player, flings 2 stingers, attempts to sting player via contact, repeat)
- Skeleton Sniper (similar idle to Goblin Archer, has aiming period before fire, short reload after firing)
Update:
- "Active Hitbox" visuals changed to use vanilla Hunter Potion effect
- Many enemies to have "stun" effect on melee hits, delaying or pushing back their attacking actions
- Blood Crawler lunge does not change direction after charge telegraph begins (timing reduced slightly)
Fix:
- BoC spawn position (was) not properly reset between runs
- Hitbox "activity" was previously blanket-enabled (for Ravens, Shadow Balls, etc). Adversely affected other enemies, now does not affect most other enemies