### PR TITLE
Ragged caster added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .config/
 Properties/
 .vscode/
+TerrariaCells.csproj.lscache
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Common/GlobalItems/FunkyModifiers.cs
+++ b/Common/GlobalItems/FunkyModifiers.cs
@@ -30,6 +30,7 @@ public enum FunkyModifierType
     ImbuedDamage,
     FrenzyFire,
     DamageOnDebuff,
+    ExtraAmmo,
     CustomAmmoBullet,
     CustomAmmoArrow,
     CustomAmmoRocket,
@@ -91,6 +92,7 @@ public partial class FunkyModifierItemModifier : GlobalItem
         // FunkyModifier.FrenzyFire(1.40f, 0.75f),
         FunkyModifier.DamageOnDebuff(1.50f, BuffID.OnFire),
         FunkyModifier.DamageOnDebuff(1.50f, BuffID.Poisoned),
+        FunkyModifier.ExtraAmmo(1.50f),
         FunkyModifier.CustomBulletAmmo(ProjectileID.ExplosiveBullet, ItemID.ExplodingBullet),
         FunkyModifier.CustomBulletAmmo(ProjectileID.BulletHighVelocity, ItemID.HighVelocityBullet),
         FunkyModifier.ApplyDebuff(BuffID.Poisoned, 30f),
@@ -118,6 +120,7 @@ public partial class FunkyModifierItemModifier : GlobalItem
             FunkyModifierType.ImbuedDamage => [ModCategory.Mana],
             FunkyModifierType.FrenzyFire => [ModCategory.Generic],
             FunkyModifierType.DamageOnDebuff => [ModCategory.Sword, ModCategory.Projectile],
+            FunkyModifierType.ExtraAmmo => [ModCategory.AmmoBullet, ModCategory.AmmoRocket],
             FunkyModifierType.CustomAmmoBullet => [ModCategory.AmmoBullet],
             FunkyModifierType.CustomAmmoArrow => [ModCategory.AmmoArrow],
             FunkyModifierType.CustomAmmoRocket => [ModCategory.AmmoRocket],
@@ -221,6 +224,7 @@ public struct FunkyModifier(FunkyModifierType type, float modifier)
                 FunkyModifierType.ImbuedDamage => "{0}% damage, {1}% mana cost",
                 FunkyModifierType.FrenzyFire => "{0}% damage, {0}% attack speed",
                 FunkyModifierType.DamageOnDebuff => "{0}% damage vs targets afflicted by {2}",// {Terraria.Lang.GetBuffName(id)}";
+                FunkyModifierType.ExtraAmmo => "{0}% more ammo",
                 FunkyModifierType.CustomAmmoBullet => "Weapon fires {2}",
                     // string localizedText = Terraria.Lang.GetProjectileName(id).Value;
                     // if (id == ProjectileID.ExplosiveBullet) {
@@ -243,7 +247,7 @@ public struct FunkyModifier(FunkyModifierType type, float modifier)
     public FunkyModifierType modifierType = type;
 
     /// <summary>
-    /// used for Damage, ProjectileVelocity, AttackSpeed, Size, ManaCost, ImbuedDamage (damage), DamageOnDebuff (damage)
+    /// used for Damage, ProjectileVelocity, AttackSpeed, Size, ManaCost, ExtraAmmo, ImbuedDamage (damage), DamageOnDebuff (damage)
     /// </summary>
     public float modifier = modifier;
 
@@ -268,6 +272,9 @@ public struct FunkyModifier(FunkyModifierType type, float modifier)
 
     public static FunkyModifier AttackSpeed(float speedMod) =>
         new(FunkyModifierType.AttackSpeed, speedMod);
+    
+    public static FunkyModifier ExtraAmmo(float ammoMod) =>
+        new(FunkyModifierType.ExtraAmmo, ammoMod);
 
     /// <summary>
     /// Note for projectiles! Projectile hitboxes can only be flatly incrememnted by integers

--- a/Common/GlobalItems/FunkyModifiersHooks.cs
+++ b/Common/GlobalItems/FunkyModifiersHooks.cs
@@ -14,6 +14,7 @@ using TerrariaCells.Common.Items;
 using TerrariaCells.Common.ModPlayers;
 using TerrariaCells.Common.Systems;
 using TerrariaCells.Common.Utilities;
+using TerrariaCells.Content.WeaponAnimations;
 using static Terraria.GameContent.Animations.IL_Actions.NPCs;
 
 namespace TerrariaCells.Common.GlobalItems;

--- a/Common/GlobalItems/TierSystemGlobalItem.cs
+++ b/Common/GlobalItems/TierSystemGlobalItem.cs
@@ -8,6 +8,7 @@ using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using TerrariaCells.Common.Items;
+using TerrariaCells.Content.WeaponAnimations;
 
 namespace TerrariaCells.Common.GlobalItems
 {

--- a/Common/GlobalNPCs/CombatNPC.cs
+++ b/Common/GlobalNPCs/CombatNPC.cs
@@ -239,6 +239,10 @@ namespace TerrariaCells.Common.GlobalNPCs
                     npc.lifeMax = 125;
                     npc.damage = 60;
                     break;
+                case NPCID.DungeonSpirit:
+                    npc.lifeMax = 5;
+                    npc.damage = 40;
+                    break;
                 case NPCID.RustyArmoredBonesAxe:
                 case NPCID.RustyArmoredBonesFlail:
                 case NPCID.RustyArmoredBonesSword:

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/DungeonSpirit.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/DungeonSpirit.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Xna.Framework.Graphics;
+
+using Terraria;
+using Terraria.GameContent;
+using Terraria.DataStructures;
+using Terraria.ID;
+using Terraria.ModLoader;
+using ReLogic.Content;
+
+using TerrariaCells.Common.Utilities;
+using TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared;
+using static TerrariaCells.Common.Utilities.NPCHelpers;
+
+namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Dungeon
+{
+    public class DungeonSpirit: GlobalNPC
+    {
+        public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
+        {
+            return entity.type == NPCID.DungeonSpirit;
+        }
+
+        public override void SetStaticDefaults()
+        {
+            NPCID.Sets.NeverDropsResourcePickups[NPCID.DungeonSpirit] = true;
+        }
+
+        public override void SetDefaults(NPC entity)
+        {
+            entity.value = 0f;
+            entity.velocity.Y = 2.0f;
+            entity.HitSound = SoundID.Item20;
+            entity.DeathSound = SoundID.Item20;
+        }
+
+        public override void OnSpawn(NPC npc, IEntitySource source) => CombatNPC.ToggleContactDamage(npc, false);
+
+        public override bool PreAI(NPC npc)
+        {
+            npc.ai[0] ++;
+            const float MaxVelocity = -5.0f;
+            const int TimeToAttack = 40;
+
+            if (npc.ai[0] < TimeToAttack)
+            {
+                npc.rotation = MathHelper.ToRadians(180);
+                float VelocityAmount =  Math.Abs(MaxVelocity) / (float)TimeToAttack;
+                npc.velocity.Y = MathHelper.Lerp(npc.velocity.Y, MaxVelocity, VelocityAmount);
+                return false;
+            }
+
+            if (npc.ai[0] == TimeToAttack)
+            {
+                CombatNPC.ToggleContactDamage(npc, true);
+                npc.DoAttackWarning();
+                return true; //Vanilla AI
+            }
+
+        return true; //Vanilla AI
+        }
+    }
+}

--- a/Common/GlobalNPCs/NPCTypes/Dungeon/RaggedCaster.cs
+++ b/Common/GlobalNPCs/NPCTypes/Dungeon/RaggedCaster.cs
@@ -1,0 +1,193 @@
+using Microsoft.Xna.Framework.Graphics;
+using ReLogic.Content;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Terraria;
+using Terraria.GameContent;
+using Terraria.ID;
+using Terraria.ModLoader;
+using Terraria.Audio;
+
+using TerrariaCells.Common.Utilities;
+using static TerrariaCells.Common.Utilities.NPCHelpers;
+
+namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
+{
+	public partial class Casters : GlobalNPC
+	{
+        public bool DrawRaggedCaster(NPC npc, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
+        {
+            Asset<Texture2D> t = TextureAssets.Npc[npc.type];
+            spriteBatch.Draw(t.Value, npc.Center - screenPos + new Vector2(0, -3), new Rectangle(npc.frame.X, CustomFrameY, npc.frame.Width, npc.frame.Height), drawColor, npc.rotation, new Vector2(t.Width() / 2, t.Height() / Main.npcFrameCount[npc.type] / 2), new Vector2(npc.scale, npc.scale), npc.direction == 1 ? SpriteEffects.FlipHorizontally : SpriteEffects.None, 0);
+            return false;
+        }
+
+        public void RaggedCasterFrame(NPC npc)
+        {
+            if (npc.ai[0] <= 40)
+            {
+                CustomFrameY = (int)TCellsUtils.LerpFloat(0, 1, npc.ai[0], 20, TCellsUtils.LerpEasing.Linear) * 54;
+            }
+            if (npc.ai[0] >= 280)
+            {
+                CustomFrameY = (int)TCellsUtils.LerpFloat(1, 0, npc.ai[0], 10, TCellsUtils.LerpEasing.Linear, 75) * 54;
+            }
+        }
+
+		public bool RaggedCasterAI(NPC npc, Player? target)
+		{
+			bool validTarget;
+			if (target != null)
+				validTarget = npc.TargetInAggroRange(target, 400, false);
+			else
+				validTarget = npc.TargetInAggroRange(400, false);
+
+            if (target != null)
+            {
+                npc.direction = npc.Center.X > target.Center.X ? -1 : 1;
+                npc.spriteDirection = npc.direction;
+            }
+
+            int Timer = (int)npc.ai[0];
+            if (Timer > 0 || validTarget)
+            {
+                npc.ai[0]++;
+                
+                //Attack Warning
+                if (Timer == 40 && npc.HasValidTarget)
+                {
+                    npc.DoAttackWarning();
+                }
+
+
+                //Attack
+                if (Timer >= 60 && Timer < 280 && npc.HasValidTarget)
+                {
+                    const int SpiritDelay = 11; //Delay between spirits being summoned
+                    const int PxPerTile = 16;
+                    const int MinDistance = 1 * PxPerTile;
+                    const int MaxDistance = 4 * PxPerTile;
+
+                    //Summon spirits
+                    if (Timer % SpiritDelay == 0)
+                    {
+                        int dist = Main.rand.Next(MinDistance, MaxDistance);
+                        int angle = Main.rand.Next(1, 360);
+
+                        Vector2 pos = npc.Center + (Vector2.UnitX * dist).RotatedBy(MathHelper.ToRadians(angle));
+                        NPC spirit = NPC.NewNPCDirect(npc.GetSource_FromAI(), (int)pos.X, (int)pos.Y, NPCID.DungeonSpirit);
+                        SoundEngine.PlaySound(SoundID.Item8.WithVolumeScale(0.5f).WithPitchOffset(0.5f), spirit.position);
+                    }
+
+                    //Create Dust
+                    if (Timer % 3 == 0)
+                    {
+                        int dist = Main.rand.Next(MinDistance, MaxDistance);
+                        int angle = Main.rand.Next(1, 360);
+
+                        Vector2 pos = npc.Center + (Vector2.UnitX * dist).RotatedBy(MathHelper.ToRadians(angle));
+                        Dust d = Dust.NewDustDirect(new Vector2(pos.X, pos.Y), 1, 1, Terraria.ID.DustID.DungeonSpirit);
+                        d.noGravity = true;
+                        d.scale = Main.rand.NextFloat(1.33f, 2.0f);
+                        d.velocity.Y = -MathF.Abs(d.velocity.Y) * 0.67f - (1 - MathF.Abs(d.velocity.X));
+                    }
+                }
+
+
+                //Determine teleportation location
+                if (Timer == 280)
+                {
+                    int direction = target.direction;
+
+                    const int PxPerTile = 16;
+                    const int MinDistance = 12 * PxPerTile;
+                    const int MaxDistance = 18 * PxPerTile;
+                    const int RayCount = 9;
+                    const int TotalAngle = 90;
+
+                    Vector2[] rays = new Vector2[RayCount];
+                    for (int i = 0; i < RayCount; i++)
+                    {
+                        float rayAngle = (float)((i - RayCount / 2) / (float)RayCount) * TotalAngle;
+                        rays[i] = (Vector2.UnitX * -direction).RotatedBy(MathHelper.ToRadians(rayAngle)) * PxPerTile;
+                    }
+
+                    for (int i = 0; i < RayCount; i++)
+                    {
+                        Vector2 start = target.Center + rays[i] * MinDistance / PxPerTile;
+                        for (int j = MinDistance / PxPerTile; j < MaxDistance / PxPerTile; j++)
+                        {
+                            Vector2 testLocation = start + rays[i];
+                            if (Collision.SolidCollision(testLocation, npc.width, npc.height))
+                                break;
+                            if (Collision.AnyCollision(testLocation, Vector2.UnitY, npc.width, npc.height, false).Y != 0)
+                                break;
+                            if (!Collision.CanHitLine(testLocation, npc.width, npc.height, target.Center, 32, 64))
+                                break;
+                            start += rays[i];
+                        }
+                        rays[i] = start;
+                    }
+                    List<Vector2> availablePositions = new List<Vector2>();
+                    availablePositions.AddRange(rays.Where(x =>
+                    {
+                        float len = (x - target.Center).Length();
+                        return len < MaxDistance + PxPerTile
+                        && len > MinDistance - PxPerTile;
+                    }));
+                    if (availablePositions.Count == 0)
+                    {
+                        availablePositions.Add(npc.position);
+                    }
+
+                    int index = Main.rand.Next(availablePositions.Count);
+                    Point pos = availablePositions[index].ToPoint();
+                    pos.Y -= 24;
+                    Vector2 ground = Utilities.TCellsUtils.FindGround(new Rectangle(pos.X, pos.Y, npc.width, npc.height), 40);
+
+                    npc.ai[2] = ground.X;
+                    npc.ai[3] = ground.Y;
+                    npc.netUpdate = true;
+                }
+
+
+                //Create Dust
+                else if (320 < Timer && Timer < 420 && MathF.Pow(Timer, 1.8f) % 60 < 18)
+                {
+                    Dust d = Dust.NewDustDirect(new Vector2(npc.ai[2], npc.ai[3]-2), npc.width, npc.height, Terraria.ID.DustID.DungeonSpirit);
+                    d.noGravity = true;
+                    d.scale = Main.rand.NextFloat(1.33f, 1.67f);
+                    d.velocity.Y = -MathF.Abs(d.velocity.Y) * 0.67f - (1 - MathF.Abs(d.velocity.X));
+                }
+
+
+                //Teleport
+                if (Timer == 420)
+                {
+                    if (npc.ai[2] != 0)
+                    {
+                        npc.position = new Vector2(npc.ai[2], npc.ai[3] - npc.height);
+                        npc.ai[2] = 0;
+                        npc.ai[3] = 0;
+                        npc.netUpdate = true;
+                        npc.TargetClosest(false);
+                    }
+                    npc.velocity.Y += 0.14f;
+                }
+
+
+                //Reset and do attack warning
+                else if (Timer >= 550)
+                {
+                    npc.ai[0] = 0;
+                }
+            }
+            
+            return false;
+		}
+    }
+}

--- a/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
+++ b/Common/GlobalNPCs/NPCTypes/Hive/Hornet.cs
@@ -50,6 +50,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
             npc.TargetClosest(false);
             if (npc.TryGetTarget(out Entity target) && npc.TargetInAggroRange(target, 512))
             {
+                npc.noTileCollide = true;
+
                 npc.ai[0] = 0;
                 npc.ai[1] = 1;
                 npc.ai[2] = -MathF.Sign(npc.position.X - target.position.X);
@@ -123,6 +125,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
             npc.TargetClosest(false);
             if (!npc.TryGetTarget(out Entity target) || !npc.TargetInAggroRange(target, 550, false))
             {
+                if (Collision.SolidCollision(npc.position - new Vector2(-20, -20), npc.width + 40, npc.height + 40)) //Start colliding with blocks if not aggro'd but only if it is in a sufficiently large area
+                    npc.noTileCollide = false;
+
                 npc.ai[0] = 0;
                 npc.ai[1] = 0;
                 npc.ai[2] = 0;
@@ -194,7 +199,8 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
             if (npc.ai[0] < (24 * 3) && (int)(npc.ai[0]) % 24 == 0 && Main.netMode != NetmodeID.MultiplayerClient)
             {
                 Vector2 vel = npc.DirectionTo(target.Center) * 6.75f;
-                Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Bottom, vel, ProjectileID.Stinger, TCellsUtils.ScaledHostileDamage(npc.damage), 1f, Main.myPlayer);
+                Projectile proj = Projectile.NewProjectileDirect(npc.GetSource_FromAI(), npc.Bottom, vel, ProjectileID.Stinger, TCellsUtils.ScaledHostileDamage(npc.damage), 1f, Main.myPlayer);
+                proj.tileCollide = false;
             }
 
             npc.direction = MathF.Sign(target.position.X - npc.position.X);
@@ -217,6 +223,16 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Hive
             if (npc.TryGetTarget(out Entity target))
             {
                 npc.ai[2] = MathF.Sign(target.position.X - npc.position.X) * MathF.Sqrt(MathF.Abs(target.position.X - npc.position.X)) * 0.0425f;
+
+                if (npc.position.Y > target.position.Y + 30) //If npc is below the target, change ai from jab to move
+                {
+                    npc.ai[0] = 0;
+                    npc.ai[1] = 1;
+                    npc.ai[2] = -MathF.Sign(npc.ai[2]);
+                    npc.ai[3] = 0;
+                    CombatNPC.ToggleContactDamage(npc, false);
+                    return;
+                }
             }
 
             if (npc.collideY && npc.oldVelocity.Y > 0 || npc.ai[3] > 0)

--- a/Common/GlobalNPCs/NPCTypes/Shared/Casters.cs
+++ b/Common/GlobalNPCs/NPCTypes/Shared/Casters.cs
@@ -42,6 +42,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                 entity.ai[1] = entity.Center.X;
                 entity.ai[2] = entity.Center.Y;
             }
+            if (entity.type == NPCID.RaggedCaster || entity.type == NPCID.RaggedCasterOpenCoat)
+            {
+                entity.knockBackResist = 0f;
+            }
         }
         public override bool PreDraw(NPC npc, SpriteBatch spriteBatch, Vector2 screenPos, Color drawColor)
         {
@@ -52,6 +56,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             if (npc.type == NPCID.CultistDevote)
             {
                 return DrawCultistDevotee(npc, spriteBatch, screenPos, drawColor);
+            }
+            if (npc.type == NPCID.RaggedCaster || npc.type == NPCID.RaggedCasterOpenCoat)
+            {
+                return DrawRaggedCaster(npc, spriteBatch, screenPos, drawColor);
             }
             return base.PreDraw(npc, spriteBatch, screenPos, drawColor);
         }
@@ -64,6 +72,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             if (npc.type == NPCID.CultistDevote)
             {
                 CultistDevoteeFrame(npc);
+            }
+            if (npc.type == NPCID.RaggedCaster || npc.type == NPCID.RaggedCasterOpenCoat)
+            {
+                RaggedCasterFrame(npc);
             }
             base.FindFrame(npc, frameHeight);
         }
@@ -93,10 +105,9 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
 
         public override bool PreAI(NPC npc)
         {
-            //for diabolist and ragged caster, use existing AI but limit its aggro range
+            //for diabolist, use existing AI but limit its aggro range
             //so they don't fire from offscreen
-            if (npc.type == NPCID.DiabolistRed || npc.type == NPCID.DiabolistWhite ||
-                npc.type == NPCID.RaggedCaster || npc.type == NPCID.RaggedCasterOpenCoat)
+            if (npc.type == NPCID.DiabolistRed || npc.type == NPCID.DiabolistWhite)
             {
                 npc.TargetClosest();
                 if (npc.HasValidTarget && !npc.TargetInAggroRange(Main.player[npc.target], 640))
@@ -105,7 +116,10 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
                 }
             }
 
-            if (npc.type != NPCID.DesertDjinn && npc.type != NPCID.CultistDevote)
+            if (npc.type != NPCID.DesertDjinn 
+             && npc.type != NPCID.CultistDevote 
+             && npc.type != NPCID.RaggedCaster
+             && npc.type != NPCID.RaggedCasterOpenCoat)
                 return base.PreAI(npc);
 
             npc.TargetClosest();
@@ -122,6 +136,11 @@ namespace TerrariaCells.Common.GlobalNPCs.NPCTypes.Shared
             {
                 return CultistDevoteeAI(npc, target);
             }
+            if (npc.type == NPCID.RaggedCaster || npc.type == NPCID.RaggedCasterOpenCoat)
+            {
+                return RaggedCasterAI(npc, target);
+            }
+
             return base.PreAI(npc);
         }
 

--- a/Common/GlobalNPCs/OnHitEffectsGlobalNPC.cs
+++ b/Common/GlobalNPCs/OnHitEffectsGlobalNPC.cs
@@ -92,14 +92,9 @@ namespace TerrariaCells.Common.GlobalNPCs
 
                                 break;
                             }
-
-
                     }
-
                 }
-
             }
-
         }
     }
 }

--- a/Common/GlobalNPCs/VanillaNPCShop.cs
+++ b/Common/GlobalNPCs/VanillaNPCShop.cs
@@ -16,6 +16,7 @@ using Terraria.Localization;
 using TerrariaCells.Common.GlobalItems;
 using TerrariaCells.Common.Items;
 using TerrariaCells.Content.UI;
+using TerrariaCells.Content.WeaponAnimations;
 
 //using static TerrariaCells.Common.Utilities.JsonUtil;
 
@@ -218,7 +219,6 @@ namespace TerrariaCells.Common.GlobalNPCs
             }
         }
     }
-
 	class NPCShopDetours : ModSystem {
         public override void Load()
         {

--- a/Common/Systems/ChestLootSpawner.cs
+++ b/Common/Systems/ChestLootSpawner.cs
@@ -12,6 +12,7 @@ using Terraria.ModLoader.IO;
 using TerrariaCells.Common.Configs;
 using TerrariaCells.Common.GlobalItems;
 using TerrariaCells.Common.ModPlayers;
+using TerrariaCells.Content.WeaponAnimations;
 
 namespace TerrariaCells.Common.Systems;
 
@@ -120,6 +121,10 @@ public class ChestLootSpawner : ModSystem, IEntitySource
                         }
 
                         FunkyModifierItemModifier.Reforge(item);
+
+                        //Set defaults again if the item is a gun so that the extra ammo mod can be applied
+                        if(Gun.TryGetGlobalItem(item, out Gun gun))
+                            gun.SetDefaults(item);
                     } else {
                         NPC.NewNPC(this, x * 16, y * 16, NPCID.Firefly);
                     }
@@ -190,6 +195,10 @@ public class ChestLootSpawner : ModSystem, IEntitySource
                         }
 
                         FunkyModifierItemModifier.Reforge(item);
+
+                        //Set defaults again if the item is a gun so that the extra ammo mod can be applied
+                        if(Gun.TryGetGlobalItem(item, out Gun gun))
+                            gun.SetDefaults(item);
                     }
                 } else {
                     NPC.NewNPC(this, (x + 1) * 16, y * 16, NPCID.Firefly);

--- a/Content/NPCs/SWATHornet.cs
+++ b/Content/NPCs/SWATHornet.cs
@@ -29,6 +29,7 @@ namespace TerrariaCells.Content.NPCs
             NPC.DeathSound = SoundID.NPCDeath1;
         }
         private ref float Timer => ref NPC.ai[0];
+        bool Aggrod = false; //True if the npc has been aggro'd. The npc never unaggros to avoid it flying off after moving behind walls.
         public override void AI()
         {
             Vector2 Speed = new Vector2(4.4f, 3.2f);
@@ -37,7 +38,7 @@ namespace TerrariaCells.Content.NPCs
             if (!NPC.HasValidTarget)
                 NPC.TargetClosest(false);
 
-            if (!NPC.TargetInAggroRange(32 * 16) && Timer < 5)
+            if (!NPC.TargetInAggroRange(32 * 16) && Timer < 5 && Aggrod == false)
             {
                 Common.GlobalNPCs.CombatNPC.ToggleContactDamage(NPC, false);
 
@@ -62,6 +63,9 @@ namespace TerrariaCells.Content.NPCs
             }
             if (NPC.TryGetTarget(out Entity target))
             {
+                NPC.noTileCollide = true;
+                Aggrod = true;
+
                 //Initial follow to near position
                 if (Timer < 30)
                 {
@@ -177,6 +181,7 @@ namespace TerrariaCells.Content.NPCs
                                 Main.myPlayer);
                             proj.hostile = true;
                             proj.friendly = false;
+                            proj.tileCollide = false;
                             proj.netUpdate = true;
                         }
                     }

--- a/Content/NPCs/SWATHornet.cs
+++ b/Content/NPCs/SWATHornet.cs
@@ -29,7 +29,6 @@ namespace TerrariaCells.Content.NPCs
             NPC.DeathSound = SoundID.NPCDeath1;
         }
         private ref float Timer => ref NPC.ai[0];
-        bool Aggrod = false; //True if the npc has been aggro'd. The npc never unaggros to avoid it flying off after moving behind walls.
         public override void AI()
         {
             Vector2 Speed = new Vector2(4.4f, 3.2f);
@@ -38,7 +37,7 @@ namespace TerrariaCells.Content.NPCs
             if (!NPC.HasValidTarget)
                 NPC.TargetClosest(false);
 
-            if (!NPC.TargetInAggroRange(32 * 16) && Timer < 5 && Aggrod == false)
+            if (!NPC.TargetInAggroRange(32 * 16) && Timer == 0)
             {
                 Common.GlobalNPCs.CombatNPC.ToggleContactDamage(NPC, false);
 
@@ -58,13 +57,11 @@ namespace TerrariaCells.Content.NPCs
                 {
                     NPC.velocity = Vector2.Lerp(NPC.velocity, NPC.velocity.SafeNormalize(Vector2.Zero) * Speed, 0.08f);
                 }
-                Timer = 0;
                 return;
             }
             if (NPC.TryGetTarget(out Entity target))
             {
                 NPC.noTileCollide = true;
-                Aggrod = true;
 
                 //Initial follow to near position
                 if (Timer < 30)
@@ -113,7 +110,7 @@ namespace TerrariaCells.Content.NPCs
                     Vector2 end = target.Center - offset;
 
                     int timer = (int)Timer - 90;
-                    if(timer == 0)
+                    if(timer == 1)
                         NPC.DoAttackWarning();
                     if (timer < 20)
                     {
@@ -185,7 +182,7 @@ namespace TerrariaCells.Content.NPCs
                             proj.netUpdate = true;
                         }
                     }
-                    int timer = (int)Timer - 200;
+                    int timer = (int)Timer - 199;
                     NPC.velocity.X = MathHelper.Lerp(-NPC.ai[1] * Speed.X, 0, MathF.Min(timer / 15f, 1));
                     NPC.velocity.Y = MathHelper.Lerp(1f, 0, MathF.Abs(timer - 30) / 30f);
 
@@ -194,7 +191,7 @@ namespace TerrariaCells.Content.NPCs
                 }
                 else
                 {
-                    Timer = 0;
+                    Timer = 1;
                     NPC.ai[1] = 0;
                     NPC.ai[2] = 0;
                     NPC.ai[3] = 0;

--- a/Content/WeaponAnimations/Gun.cs
+++ b/Content/WeaponAnimations/Gun.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Terraria;
 using Terraria.Audio;
+using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.ModLoader;
 using TerrariaCells.Common.GlobalItems;
@@ -150,8 +151,8 @@ namespace TerrariaCells.Content.WeaponAnimations
                 {
                     case FunkyModifierType.ExtraAmmo:
                     {
-                        //Scale ammo of the weapon if it has the corresponding modifiers
-                        MaxAmmo = ScaleAmmo(MaxAmmo, modifier.modifier);
+                        //Scale ammo of the weapon if it has the extra ammo modifier
+                        MaxAmmo = (int)(MaxAmmo * modifier.modifier);
                         break;
                     }
                 }
@@ -167,6 +168,11 @@ namespace TerrariaCells.Content.WeaponAnimations
                 Common.Systems.DeadCellsUISystem.ToggleActive<Content.UI.Reload>(true);
             }
         }
+
+        public override void OnCreated(Item item, ItemCreationContext context)
+        {
+            SetDefaults(item); //Literally just set defaults when creating the item so that the extra ammo mod is applied properly
+        }    
 
         public override GlobalItem Clone(Item from, Item to)
         {
@@ -197,11 +203,5 @@ namespace TerrariaCells.Content.WeaponAnimations
 				gun = item.GetGlobalItem<Launcher>();
 			return gun != null;
 		}
-
-        //Method to scale the ammo of the weapon if it has the extra ammo modifier
-        private int ScaleAmmo(int MaxAmmo, float AmmoScale)
-        {
-            return (int)(MaxAmmo * AmmoScale);
-        }
     }
 }

--- a/Content/WeaponAnimations/Gun.cs
+++ b/Content/WeaponAnimations/Gun.cs
@@ -8,6 +8,7 @@ using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
 using Terraria.ModLoader;
+using TerrariaCells.Common.GlobalItems;
 
 namespace TerrariaCells.Content.WeaponAnimations
 {
@@ -28,7 +29,6 @@ namespace TerrariaCells.Content.WeaponAnimations
         public int OriginalUseTime;
         public int OriginalUseAnimation;
         public int OriginalReuseDelay;
-        
 
         public override void SetDefaults(Item item)
         {
@@ -138,6 +138,24 @@ namespace TerrariaCells.Content.WeaponAnimations
                     break;
                  
             }
+            
+            if (!item.TryGetGlobalItem(out FunkyModifierItemModifier funkyModifiers))
+            {
+                return;
+            }
+        
+            foreach (FunkyModifier modifier in funkyModifiers.modifiers ?? [])
+            {
+                switch (modifier.modifierType)
+                {
+                    case FunkyModifierType.ExtraAmmo:
+                    {
+                        //Scale ammo of the weapon if it has the corresponding modifiers
+                        MaxAmmo = ScaleAmmo(MaxAmmo, modifier.modifier);
+                        break;
+                    }
+                }
+            }
 
             Ammo = MaxAmmo;
         }
@@ -179,5 +197,11 @@ namespace TerrariaCells.Content.WeaponAnimations
 				gun = item.GetGlobalItem<Launcher>();
 			return gun != null;
 		}
+
+        //Method to scale the ammo of the weapon if it has the extra ammo modifier
+        private int ScaleAmmo(int MaxAmmo, float AmmoScale)
+        {
+            return (int)(MaxAmmo * AmmoScale);
+        }
     }
 }

--- a/Localization/en-US_Mods.TerrariaCells.hjson
+++ b/Localization/en-US_Mods.TerrariaCells.hjson
@@ -414,6 +414,7 @@ Tooltips: {
 		ImbuedDamage: "{0}% damage, {1}% mana cost"
 		FrenzyFire: "{0}% damage, {0}% attack speed"
 		DamageOnDebuff: "{0}% damage vs targets afflicted by {2}"
+		ExtraAmmo: "{0}% more ammo"
 		CustomAmmoBullet: Weapon fires {2}s
 		ApplyDebuff: Inflicts {2} for {3} seconds
 		CritsExplode: Critical strikes are explosive


### PR DESCRIPTION
Ragged caster added, summons 20 dungeon spirits which fly vertically upwards for a short time and then attack the player. They do not drop food items or mana stars and they don't trigger melee rally. 

I also made the code for the hornets passing through walls slightly cleaner by removing the Aggrod variable and making sure that npc.ai[0] is never equal to 0 once it has been aggrod.